### PR TITLE
Assunto: feat: Implementa permissões por studio para isolamento de dados

### DIFF
--- a/backend/alunos/views.py
+++ b/backend/alunos/views.py
@@ -5,6 +5,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 from .models import Aluno
 from .serializers import AlunoSerializer
 from .permissions import IsAdminOrRecepcionista
+from core.permissions import StudioPermissionMixin
 
 @extend_schema(
     tags=['Alunos'],
@@ -43,7 +44,7 @@ Fornece endpoints para:
         description='Remove um aluno.'
     )
 )
-class AlunoViewSet(viewsets.ModelViewSet):
+class AlunoViewSet(StudioPermissionMixin, viewsets.ModelViewSet):
     """
     ViewSet que fornece a API completa para o gerenciamento de Alunos.
     
@@ -58,3 +59,4 @@ class AlunoViewSet(viewsets.ModelViewSet):
     serializer_class = AlunoSerializer
     permission_classes = [IsAdminOrRecepcionista]
     lookup_field = 'usuario__cpf'
+    studio_filter_field = 'unidades'

--- a/backend/core/permissions.py
+++ b/backend/core/permissions.py
@@ -1,0 +1,48 @@
+# core/permissions.py
+class StudioPermissionMixin:
+    """
+    Mixin para filtrar querysets com base nos estúdios do colaborador logado.
+    Aplica a regra de que ADMIN_MASTER vê tudo, e outros colaboradores
+    (Admin, Recep, etc.) veem apenas dados de seus estúdios.
+    """
+    # A ViewSet que usar este mixin DEVE definir este campo.
+    # Ex: 'studio', 'aula__studio', 'unidades'
+    studio_filter_field = None
+
+    def get_queryset(self):
+        """
+        Sobrescreve o método get_queryset da ViewSet para aplicar a lógica de filtro.
+        """
+        # Pega a queryset original definida na ViewSet (ex: Aula.objects.all())
+        queryset = super().get_queryset()
+        user = self.request.user
+
+        # Se o usuário não for um colaborador (ex: Aluno), retorna a queryset original.
+        # Alunos precisam ver todas as aulas para poderem se agendar.
+        if not user.is_authenticated or not hasattr(user, 'colaborador'):
+            return queryset
+
+        perfis = user.colaborador.perfis.values_list('nome', flat=True)
+
+        # 1. ADMIN_MASTER sempre vê tudo.
+        if 'ADMIN_MASTER' in perfis:
+            return queryset
+
+        # 2. Outros perfis de staff (Admin, Recep, etc.) têm os dados filtrados.
+        if any(p in ['ADMINISTRADOR', 'RECEPCIONISTA', 'INSTRUTOR', 'FISIOTERAPEUTA'] for p in perfis):
+            if not self.studio_filter_field:
+                # Gera um erro claro se o mixin for usado sem configurar o campo de filtro.
+                raise NotImplementedError(
+                    f"{self.__class__.__name__} usa StudioPermissionMixin mas não definiu 'studio_filter_field'."
+                )
+
+            studios_do_colaborador = user.colaborador.unidades.all()
+            
+            # Constrói o filtro dinamicamente. Ex: {'studio__in': studios_do_colaborador}
+            filter_kwargs = {f"{self.studio_filter_field}__in": studios_do_colaborador}
+            
+            # Retorna a queryset filtrada e remove duplicatas se houver joins.
+            return queryset.filter(**filter_kwargs).distinct()
+
+        # Por segurança, se um colaborador não tiver um perfil que se encaixe nas regras, não retorna nada.
+        return queryset.none()

--- a/backend/usuarios/views.py
+++ b/backend/usuarios/views.py
@@ -3,6 +3,7 @@ from rest_framework import viewsets, permissions
 from drf_spectacular.utils import extend_schema
 from .models import Usuario, Colaborador
 from .serializers import UsuarioSerializer, ColaboradorSerializer
+from core.permissions import StudioPermissionMixin
 
 from .permissions import IsAdminMaster, IsAdminMasterOrAdministrador
 
@@ -53,7 +54,7 @@ Fornece endpoints para:
 **Nota:** Apenas usuários com perfil de 'Admin Master' podem realizar esta ação.
 '''
 )
-class ColaboradorViewSet(viewsets.ModelViewSet):
+class ColaboradorViewSet(StudioPermissionMixin, viewsets.ModelViewSet):
     """
     ViewSet para gerenciar os perfis de colaborador (modelo Colaborador).
     
@@ -70,4 +71,5 @@ class ColaboradorViewSet(viewsets.ModelViewSet):
     
     # Apenas o Admin Master pode gerenciar perfis de colaborador.
     # Esta é uma permissão mais restrita para uma ação mais sensível.
-    permission_classes = [IsAdminMaster]
+    permission_classes = [IsAdminMasterOrAdministrador]
+    studio_filter_field = 'unidades'


### PR DESCRIPTION
Corpo:

Este commit introduz um sistema de permissões baseado em estúdios para garantir o isolamento de dados (multi-tenancy) em toda a aplicação.

Administradores e outros colaboradores agora têm acesso apenas aos dados (agendamentos, alunos, outros colaboradores) pertencentes aos estúdios aos quais estão formalmente associados. O perfil ADMIN_MASTER mantém sua visibilidade global sobre todos os estúdios.

Principais mudanças:

Criação do StudioPermissionMixin: Uma classe mixin reutilizável foi criada em core/permissions.py para centralizar a lógica de filtragem por estúdio, garantindo consistência e manutenibilidade.
Refatoração das Views: O mixin foi aplicado às ViewSets nos módulos agendamentos, usuarios (ColaboradorViewSet) e alunos, substituindo a lógica de permissão anterior.
Ajuste de Permissão: A ColaboradorViewSet teve sua permissão ajustada de IsAdminMaster para IsAdminMasterOrAdministrador para permitir que administradores de estúdio acessem a view, que então é filtrada pelo mixin.