### PR TITLE
Adiciona um novo endpoint GET /api/usuarios/perfis/ para listar todos…

### DIFF
--- a/backend/usuarios/serializers.py
+++ b/backend/usuarios/serializers.py
@@ -1,8 +1,20 @@
 # usuarios/serializers.py
 from rest_framework import serializers
 from django.db import IntegrityError
-from .models import Usuario, Colaborador, Endereco
+from .models import Usuario, Colaborador, Endereco, Perfil
 from studios.models import Studio, ColaboradorStudio, FuncaoOperacional
+
+
+class PerfilSerializer(serializers.ModelSerializer):
+    """
+    Serializer para o modelo Perfil. Retorna o ID e o nome legível do perfil.
+    """
+    nome = serializers.CharField(source='get_nome_display', read_only=True)
+
+    class Meta:
+        model = Perfil
+        fields = ['id', 'nome']
+
 
 class EnderecoSerializer(serializers.ModelSerializer):
     """
@@ -92,6 +104,7 @@ class ColaboradorSerializer(serializers.ModelSerializer):
     """
     Serializer para o modelo Colaborador. Gerencia o perfil profissional do usuário.
     """
+    perfis = PerfilSerializer(many=True, read_only=True)
     endereco = EnderecoSerializer()
     nome_completo = serializers.CharField(source='usuario.get_full_name', read_only=True)
     definir_nome_completo = serializers.CharField(write_only=True, required=False, help_text="Defina o nome completo para atualizar o usuário relacionado.")

--- a/backend/usuarios/urls.py
+++ b/backend/usuarios/urls.py
@@ -1,22 +1,17 @@
 # usuarios/urls.py
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import UsuarioViewSet, ColaboradorViewSet
+from .views import (
+    UsuarioViewSet, 
+    ColaboradorViewSet,
+    PerfisListView,
+)
 
-# DefaultRouter é uma ferramenta do Django Rest Framework que cria automaticamente
-# as URLs para um ViewSet.
 router = DefaultRouter()
+router.register(r'usuarios', UsuarioViewSet, basename='usuario')
+router.register(r'colaboradores', ColaboradorViewSet, basename='colaborador')
 
-# Registra o ViewSet de usuários com o prefixo de URL 'usuarios'.
-# Isso irá gerar rotas como /usuarios/, /usuarios/{id}/, etc.
-router.register(r'usuarios', UsuarioViewSet)
-
-# Registra o ViewSet de colaboradores com o prefixo de URL 'colaboradores'.
-# Isso irá gerar rotas como /colaboradores/, /colaboradores/{usuario__cpf}/, etc.
-router.register(r'colaboradores', ColaboradorViewSet)
-
-# As URLs da API são incluídas no padrão de URL principal do aplicativo.
-# O router lida com a criação de todas as rotas necessárias para os ViewSets registrados.
 urlpatterns = [
     path('', include(router.urls)),
+    path('perfis/', PerfisListView.as_view(), name='perfis-list'),
 ]


### PR DESCRIPTION
… os perfis de usuário (ex: Instrutor, Admin). A rota foi agrupada sob a tag 'Colaboradores' no Swagger para melhor organização.

Além disso, o serializer de Colaborador foi aprimorado para aninhar os dados do perfil. O campo 'perfis' agora retorna o objeto completo ({id, nome}) em vez de apenas a chave primária, tornando a resposta da API mais informativa e consistente com outras partes do sistema.

- Cria PerfilSerializer e PerfisListView.
- Adiciona a rota /api/usuarios/perfis/.
- Modifica ColaboradorSerializer para usar o PerfilSerializer aninhado.
- Corrige erros de importação que impediam a inicialização do servidor.